### PR TITLE
fix(rag-server): bound in-memory agent run registry

### DIFF
--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use agent_core::ports::{ApprovalPort, BaselineAnswerPort, ChatPort, RetrievalPort};
 use agent_core::runtime::AgentRuntime;
@@ -18,6 +19,7 @@ pub struct AgentManager {
     registry: agent_core::AgentRegistry,
     runtimes: HashMap<String, Arc<dyn AgentRuntime>>,
     runs: Arc<DashMap<RunId, RunRecord>>,
+    run_registry_policy: RunRegistryPolicy,
 }
 
 #[derive(Debug, Clone)]
@@ -27,6 +29,7 @@ pub struct RunRecord {
     pub query: String,
     pub collection: String,
     pub tenant: String,
+    inserted_at: Instant,
 }
 
 #[derive(Debug, Clone)]
@@ -43,6 +46,17 @@ pub struct RunWithMetadata {
     pub record: RunRecord,
     pub result: AgentRunResult,
 }
+
+#[derive(Debug, Clone, Copy)]
+struct RunRegistryPolicy {
+    ttl: Duration,
+    max_entries: usize,
+}
+
+const DEFAULT_RUN_REGISTRY_TTL_SECS: u64 = 60 * 60 * 24;
+const DEFAULT_RUN_REGISTRY_MAX_ENTRIES: usize = 10_000;
+const RUN_REGISTRY_TTL_ENV: &str = "AGENT_RUN_REGISTRY_TTL_SECS";
+const RUN_REGISTRY_MAX_ENTRIES_ENV: &str = "AGENT_RUN_REGISTRY_MAX_ENTRIES";
 
 impl AgentManager {
     pub async fn load_default(
@@ -75,7 +89,12 @@ impl AgentManager {
             runtimes.insert(agent_id.clone(), runtime);
         }
 
-        Ok(Self { registry, runtimes, runs: Arc::new(DashMap::new()) })
+        Ok(Self {
+            registry,
+            runtimes,
+            runs: Arc::new(DashMap::new()),
+            run_registry_policy: load_run_registry_policy()?,
+        })
     }
 
     pub fn list_agents(&self) -> Vec<AgentDescriptor> {
@@ -96,6 +115,7 @@ impl AgentManager {
         tenant: String,
         max_steps: usize,
     ) -> Result<AgentRunResult> {
+        self.prune_run_registry();
         let runtime = self
             .runtimes
             .get(agent_id)
@@ -118,12 +138,21 @@ impl AgentManager {
                 query,
                 collection,
                 tenant,
+                inserted_at: Instant::now(),
             },
         );
+        self.prune_run_registry();
         Ok(result)
     }
 
     pub async fn inspect(&self, run_id: RunId) -> Result<Option<RunWithMetadata>> {
+        self.inspect_inner(run_id, true).await
+    }
+
+    async fn inspect_inner(&self, run_id: RunId, prune: bool) -> Result<Option<RunWithMetadata>> {
+        if prune {
+            self.prune_run_registry();
+        }
         let record = match self.runs.get(&run_id) {
             Some(record) => record.clone(),
             None => return Ok(None),
@@ -154,6 +183,7 @@ impl AgentManager {
         tenant: &str,
         agent_id: Option<&str>,
     ) -> Result<Vec<RunWithMetadata>> {
+        self.prune_run_registry();
         let records: Vec<RunRecord> = self
             .runs
             .iter()
@@ -171,7 +201,7 @@ impl AgentManager {
 
         let mut runs = Vec::new();
         for record in records {
-            if let Some(run) = self.inspect(record.run_id).await? {
+            if let Some(run) = self.inspect_inner(record.run_id, false).await? {
                 runs.push(run);
             }
         }
@@ -186,6 +216,7 @@ impl AgentManager {
         approved: bool,
         reason: Option<String>,
     ) -> Result<AgentRunResult> {
+        self.prune_run_registry();
         let record = self
             .runs
             .get(&run_id)
@@ -201,6 +232,80 @@ impl AgentManager {
             .ok_or_else(|| anyhow!("runtime for agent '{}' is unavailable", record.agent_id))?;
         runtime.resume(run_id, CheckpointDecision { approved, reason }).await
     }
+
+    fn prune_run_registry(&self) {
+        let now = Instant::now();
+        let expired = prune_expired_runs(&self.runs, now, self.run_registry_policy.ttl);
+        let overflow = prune_to_max_entries(&self.runs, self.run_registry_policy.max_entries);
+        if expired > 0 || overflow > 0 {
+            tracing::debug!(
+                expired,
+                overflow,
+                max_entries = self.run_registry_policy.max_entries,
+                ttl_secs = self.run_registry_policy.ttl.as_secs(),
+                remaining = self.runs.len(),
+                "pruned in-memory agent run registry"
+            );
+        }
+    }
+}
+
+fn load_run_registry_policy() -> Result<RunRegistryPolicy> {
+    fn parse_env<T>(name: &str) -> Result<Option<T>>
+    where
+        T: std::str::FromStr,
+        <T as std::str::FromStr>::Err: std::error::Error + Send + Sync + 'static,
+    {
+        std::env::var(name)
+            .ok()
+            .map(|raw| raw.parse::<T>().with_context(|| format!("parsing {name}")))
+            .transpose()
+    }
+
+    let ttl_secs: u64 = parse_env(RUN_REGISTRY_TTL_ENV)?.unwrap_or(DEFAULT_RUN_REGISTRY_TTL_SECS);
+    if ttl_secs == 0 {
+        anyhow::bail!("{RUN_REGISTRY_TTL_ENV} must be greater than zero");
+    }
+
+    let max_entries: usize =
+        parse_env(RUN_REGISTRY_MAX_ENTRIES_ENV)?.unwrap_or(DEFAULT_RUN_REGISTRY_MAX_ENTRIES);
+    if max_entries == 0 {
+        anyhow::bail!("{RUN_REGISTRY_MAX_ENTRIES_ENV} must be greater than zero");
+    }
+
+    Ok(RunRegistryPolicy { ttl: Duration::from_secs(ttl_secs), max_entries })
+}
+
+fn prune_expired_runs(runs: &DashMap<RunId, RunRecord>, now: Instant, ttl: Duration) -> usize {
+    let stale_run_ids: Vec<RunId> = runs
+        .iter()
+        .filter_map(|entry| {
+            let age = now.saturating_duration_since(entry.value().inserted_at);
+            if age >= ttl { Some(*entry.key()) } else { None }
+        })
+        .collect();
+    let removed = stale_run_ids.len();
+    for run_id in stale_run_ids {
+        runs.remove(&run_id);
+    }
+    removed
+}
+
+fn prune_to_max_entries(runs: &DashMap<RunId, RunRecord>, max_entries: usize) -> usize {
+    let current_len = runs.len();
+    if current_len <= max_entries {
+        return 0;
+    }
+
+    let overflow = current_len - max_entries;
+    let mut records_by_age: Vec<(RunId, Instant)> =
+        runs.iter().map(|entry| (*entry.key(), entry.value().inserted_at)).collect();
+    records_by_age.sort_by_key(|(_, inserted_at)| *inserted_at);
+
+    for (run_id, _) in records_by_age.into_iter().take(overflow) {
+        runs.remove(&run_id);
+    }
+    overflow
 }
 
 fn describe_agent(spec: &AgentSpec) -> AgentDescriptor {
@@ -433,8 +538,21 @@ impl ApprovalPort for PauseForApproval {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::time::{Duration, Instant};
 
     use super::*;
+    use uuid::Uuid;
+
+    fn sample_record(run_id: RunId, inserted_at: Instant) -> RunRecord {
+        RunRecord {
+            run_id,
+            agent_id: "rag_spike".to_string(),
+            query: "test query".to_string(),
+            collection: "test-collection".to_string(),
+            tenant: "test-tenant".to_string(),
+            inserted_at,
+        }
+    }
 
     #[test]
     fn map_scored_chunk_for_summary_preserves_metadata_and_provenance() {
@@ -473,5 +591,43 @@ mod tests {
         assert_eq!(fused.score_type, chunk.score_type);
         assert_eq!(fused.sources, chunk.sources);
         assert_eq!(fused.source_scores, chunk.source_scores);
+    }
+
+    #[test]
+    fn prune_expired_runs_removes_entries_older_than_ttl() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let stale_run = Uuid::new_v4();
+        let fresh_run = Uuid::new_v4();
+        let ttl = Duration::from_secs(30);
+
+        runs.insert(stale_run, sample_record(stale_run, now - Duration::from_secs(120)));
+        runs.insert(fresh_run, sample_record(fresh_run, now - Duration::from_secs(5)));
+
+        let removed = prune_expired_runs(&runs, now, ttl);
+
+        assert_eq!(removed, 1);
+        assert!(!runs.contains_key(&stale_run));
+        assert!(runs.contains_key(&fresh_run));
+    }
+
+    #[test]
+    fn prune_to_max_entries_keeps_newest_runs() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let oldest = Uuid::new_v4();
+        let middle = Uuid::new_v4();
+        let newest = Uuid::new_v4();
+
+        runs.insert(oldest, sample_record(oldest, now - Duration::from_secs(30)));
+        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20)));
+        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10)));
+
+        let removed = prune_to_max_entries(&runs, 2);
+
+        assert_eq!(removed, 1);
+        assert!(!runs.contains_key(&oldest));
+        assert!(runs.contains_key(&middle));
+        assert!(runs.contains_key(&newest));
     }
 }

--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -177,11 +177,19 @@ impl AgentManager {
         run_id: RunId,
         tenant: &str,
     ) -> Result<Option<RunWithMetadata>> {
-        match self.inspect(run_id).await? {
-            Some(run) if run.record.tenant == tenant => Ok(Some(run)),
-            Some(_) => Ok(None),
-            None => Ok(None),
+        let is_owned_by_tenant = match self.runs.get(&run_id) {
+            Some(record) if record.tenant == tenant => true,
+            Some(_) => false,
+            None => return Ok(None),
+        };
+
+        if !is_owned_by_tenant {
+            // Do not protect foreign runs from pruning during unauthorized probes.
+            self.prune_run_registry();
+            return Ok(None);
         }
+
+        self.inspect_inner(run_id, Some(run_id)).await
     }
 
     pub async fn list_runs(

--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -30,6 +30,7 @@ pub struct RunRecord {
     pub collection: String,
     pub tenant: String,
     inserted_at: Instant,
+    awaiting_approval: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -139,6 +140,7 @@ impl AgentManager {
                 collection,
                 tenant,
                 inserted_at: Instant::now(),
+                awaiting_approval: result.pending_checkpoint.is_some(),
             },
         );
         self.prune_run_registry();
@@ -146,12 +148,16 @@ impl AgentManager {
     }
 
     pub async fn inspect(&self, run_id: RunId) -> Result<Option<RunWithMetadata>> {
-        self.inspect_inner(run_id, true).await
+        self.inspect_inner(run_id, Some(run_id)).await
     }
 
-    async fn inspect_inner(&self, run_id: RunId, prune: bool) -> Result<Option<RunWithMetadata>> {
-        if prune {
-            self.prune_run_registry();
+    async fn inspect_inner(
+        &self,
+        run_id: RunId,
+        protected_run_id: Option<RunId>,
+    ) -> Result<Option<RunWithMetadata>> {
+        if let Some(protected_run_id) = protected_run_id {
+            self.prune_run_registry_with_protected(Some(protected_run_id));
         }
         let record = match self.runs.get(&run_id) {
             Some(record) => record.clone(),
@@ -201,7 +207,7 @@ impl AgentManager {
 
         let mut runs = Vec::new();
         for record in records {
-            if let Some(run) = self.inspect_inner(record.run_id, false).await? {
+            if let Some(run) = self.inspect_inner(record.run_id, None).await? {
                 runs.push(run);
             }
         }
@@ -230,7 +236,11 @@ impl AgentManager {
             .get(&record.agent_id)
             .cloned()
             .ok_or_else(|| anyhow!("runtime for agent '{}' is unavailable", record.agent_id))?;
-        runtime.resume(run_id, CheckpointDecision { approved, reason }).await
+        let result = runtime.resume(run_id, CheckpointDecision { approved, reason }).await?;
+        if let Some(mut entry) = self.runs.get_mut(&run_id) {
+            entry.awaiting_approval = result.pending_checkpoint.is_some();
+        }
+        Ok(result)
     }
 
     fn prune_run_registry(&self) {
@@ -297,6 +307,9 @@ fn prune_expired_runs(
             if protected_run_id.is_some_and(|run_id| run_id == *entry.key()) {
                 return None;
             }
+            if entry.value().awaiting_approval {
+                return None;
+            }
             let age = now.saturating_duration_since(entry.value().inserted_at);
             if age >= ttl { Some(*entry.key()) } else { None }
         })
@@ -323,6 +336,8 @@ fn prune_to_max_entries(
         .iter()
         .filter_map(|entry| {
             if protected_run_id.is_some_and(|run_id| run_id == *entry.key()) {
+                None
+            } else if entry.value().awaiting_approval {
                 None
             } else {
                 Some((*entry.key(), entry.value().inserted_at))
@@ -572,7 +587,7 @@ mod tests {
     use super::*;
     use uuid::Uuid;
 
-    fn sample_record(run_id: RunId, inserted_at: Instant) -> RunRecord {
+    fn sample_record(run_id: RunId, inserted_at: Instant, awaiting_approval: bool) -> RunRecord {
         RunRecord {
             run_id,
             agent_id: "rag_spike".to_string(),
@@ -580,6 +595,7 @@ mod tests {
             collection: "test-collection".to_string(),
             tenant: "test-tenant".to_string(),
             inserted_at,
+            awaiting_approval,
         }
     }
 
@@ -630,8 +646,8 @@ mod tests {
         let fresh_run = Uuid::new_v4();
         let ttl = Duration::from_secs(30);
 
-        runs.insert(stale_run, sample_record(stale_run, now - Duration::from_secs(120)));
-        runs.insert(fresh_run, sample_record(fresh_run, now - Duration::from_secs(5)));
+        runs.insert(stale_run, sample_record(stale_run, now - Duration::from_secs(120), false));
+        runs.insert(fresh_run, sample_record(fresh_run, now - Duration::from_secs(5), false));
 
         let removed = prune_expired_runs(&runs, now, ttl, None);
 
@@ -648,9 +664,9 @@ mod tests {
         let middle = Uuid::new_v4();
         let newest = Uuid::new_v4();
 
-        runs.insert(oldest, sample_record(oldest, now - Duration::from_secs(30)));
-        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20)));
-        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10)));
+        runs.insert(oldest, sample_record(oldest, now - Duration::from_secs(30), false));
+        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20), false));
+        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10), false));
 
         let removed = prune_to_max_entries(&runs, 2, None);
 
@@ -668,10 +684,10 @@ mod tests {
         let stale_unprotected = Uuid::new_v4();
         let ttl = Duration::from_secs(30);
 
-        runs.insert(protected, sample_record(protected, now - Duration::from_secs(120)));
+        runs.insert(protected, sample_record(protected, now - Duration::from_secs(120), false));
         runs.insert(
             stale_unprotected,
-            sample_record(stale_unprotected, now - Duration::from_secs(120)),
+            sample_record(stale_unprotected, now - Duration::from_secs(120), false),
         );
 
         let removed = prune_expired_runs(&runs, now, ttl, Some(protected));
@@ -691,15 +707,59 @@ mod tests {
 
         runs.insert(
             protected_oldest,
-            sample_record(protected_oldest, now - Duration::from_secs(30)),
+            sample_record(protected_oldest, now - Duration::from_secs(30), false),
         );
-        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20)));
-        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10)));
+        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20), false));
+        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10), false));
 
         let removed = prune_to_max_entries(&runs, 2, Some(protected_oldest));
 
         assert_eq!(removed, 1);
         assert!(runs.contains_key(&protected_oldest));
+        assert!(!runs.contains_key(&middle));
+        assert!(runs.contains_key(&newest));
+    }
+
+    #[test]
+    fn prune_expired_runs_keeps_awaiting_approval_run() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let awaiting = Uuid::new_v4();
+        let stale_unprotected = Uuid::new_v4();
+        let ttl = Duration::from_secs(30);
+
+        runs.insert(awaiting, sample_record(awaiting, now - Duration::from_secs(120), true));
+        runs.insert(
+            stale_unprotected,
+            sample_record(stale_unprotected, now - Duration::from_secs(120), false),
+        );
+
+        let removed = prune_expired_runs(&runs, now, ttl, None);
+
+        assert_eq!(removed, 1);
+        assert!(runs.contains_key(&awaiting));
+        assert!(!runs.contains_key(&stale_unprotected));
+    }
+
+    #[test]
+    fn prune_to_max_entries_keeps_awaiting_approval_run() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let awaiting_oldest = Uuid::new_v4();
+        let middle = Uuid::new_v4();
+        let newest = Uuid::new_v4();
+
+        runs.insert(
+            awaiting_oldest,
+            sample_record(awaiting_oldest, now - Duration::from_secs(30), true),
+        );
+        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20), false));
+        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10), false));
+
+        let removed = prune_to_max_entries(&runs, 2, None);
+
+        assert_eq!(removed, 1);
+        assert!(runs.contains_key(&awaiting_oldest));
         assert!(!runs.contains_key(&middle));
         assert!(runs.contains_key(&newest));
     }

--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -239,6 +239,7 @@ impl AgentManager {
         let result = runtime.resume(run_id, CheckpointDecision { approved, reason }).await?;
         if let Some(mut entry) = self.runs.get_mut(&run_id) {
             entry.awaiting_approval = result.pending_checkpoint.is_some();
+            entry.inserted_at = Instant::now();
         }
         Ok(result)
     }
@@ -332,21 +333,20 @@ fn prune_to_max_entries(
     }
 
     let overflow = current_len - max_entries;
-    let mut records_by_age: Vec<(RunId, Instant)> = runs
+    let mut eviction_candidates: Vec<(RunId, bool, Instant)> = runs
         .iter()
         .filter_map(|entry| {
             if protected_run_id.is_some_and(|run_id| run_id == *entry.key()) {
                 None
-            } else if entry.value().awaiting_approval {
-                None
             } else {
-                Some((*entry.key(), entry.value().inserted_at))
+                Some((*entry.key(), entry.value().awaiting_approval, entry.value().inserted_at))
             }
         })
         .collect();
-    records_by_age.sort_by_key(|(_, inserted_at)| *inserted_at);
+    eviction_candidates
+        .sort_by_key(|(_, awaiting_approval, inserted_at)| (*awaiting_approval, *inserted_at));
 
-    for (run_id, _) in records_by_age.into_iter().take(overflow) {
+    for (run_id, _, _) in eviction_candidates.into_iter().take(overflow) {
         runs.remove(&run_id);
     }
     current_len.saturating_sub(runs.len())
@@ -762,5 +762,28 @@ mod tests {
         assert!(runs.contains_key(&awaiting_oldest));
         assert!(!runs.contains_key(&middle));
         assert!(runs.contains_key(&newest));
+    }
+
+    #[test]
+    fn prune_to_max_entries_evicts_awaiting_approval_when_needed_for_cap() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let awaiting_oldest = Uuid::new_v4();
+        let awaiting_newer = Uuid::new_v4();
+
+        runs.insert(
+            awaiting_oldest,
+            sample_record(awaiting_oldest, now - Duration::from_secs(30), true),
+        );
+        runs.insert(
+            awaiting_newer,
+            sample_record(awaiting_newer, now - Duration::from_secs(10), true),
+        );
+
+        let removed = prune_to_max_entries(&runs, 1, None);
+
+        assert_eq!(removed, 1);
+        assert!(!runs.contains_key(&awaiting_oldest));
+        assert!(runs.contains_key(&awaiting_newer));
     }
 }

--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -216,7 +216,6 @@ impl AgentManager {
         approved: bool,
         reason: Option<String>,
     ) -> Result<AgentRunResult> {
-        self.prune_run_registry();
         let record = self
             .runs
             .get(&run_id)
@@ -225,6 +224,7 @@ impl AgentManager {
         if record.tenant != tenant {
             return Err(anyhow!("unknown run '{run_id}'"));
         }
+        self.prune_run_registry_with_protected(Some(run_id));
         let runtime = self
             .runtimes
             .get(&record.agent_id)
@@ -234,9 +234,18 @@ impl AgentManager {
     }
 
     fn prune_run_registry(&self) {
+        self.prune_run_registry_with_protected(None);
+    }
+
+    fn prune_run_registry_with_protected(&self, protected_run_id: Option<RunId>) {
         let now = Instant::now();
-        let expired = prune_expired_runs(&self.runs, now, self.run_registry_policy.ttl);
-        let overflow = prune_to_max_entries(&self.runs, self.run_registry_policy.max_entries);
+        let expired =
+            prune_expired_runs(&self.runs, now, self.run_registry_policy.ttl, protected_run_id);
+        let overflow = prune_to_max_entries(
+            &self.runs,
+            self.run_registry_policy.max_entries,
+            protected_run_id,
+        );
         if expired > 0 || overflow > 0 {
             tracing::debug!(
                 expired,
@@ -276,10 +285,18 @@ fn load_run_registry_policy() -> Result<RunRegistryPolicy> {
     Ok(RunRegistryPolicy { ttl: Duration::from_secs(ttl_secs), max_entries })
 }
 
-fn prune_expired_runs(runs: &DashMap<RunId, RunRecord>, now: Instant, ttl: Duration) -> usize {
+fn prune_expired_runs(
+    runs: &DashMap<RunId, RunRecord>,
+    now: Instant,
+    ttl: Duration,
+    protected_run_id: Option<RunId>,
+) -> usize {
     let stale_run_ids: Vec<RunId> = runs
         .iter()
         .filter_map(|entry| {
+            if protected_run_id.is_some_and(|run_id| run_id == *entry.key()) {
+                return None;
+            }
             let age = now.saturating_duration_since(entry.value().inserted_at);
             if age >= ttl { Some(*entry.key()) } else { None }
         })
@@ -291,21 +308,33 @@ fn prune_expired_runs(runs: &DashMap<RunId, RunRecord>, now: Instant, ttl: Durat
     removed
 }
 
-fn prune_to_max_entries(runs: &DashMap<RunId, RunRecord>, max_entries: usize) -> usize {
+fn prune_to_max_entries(
+    runs: &DashMap<RunId, RunRecord>,
+    max_entries: usize,
+    protected_run_id: Option<RunId>,
+) -> usize {
     let current_len = runs.len();
     if current_len <= max_entries {
         return 0;
     }
 
     let overflow = current_len - max_entries;
-    let mut records_by_age: Vec<(RunId, Instant)> =
-        runs.iter().map(|entry| (*entry.key(), entry.value().inserted_at)).collect();
+    let mut records_by_age: Vec<(RunId, Instant)> = runs
+        .iter()
+        .filter_map(|entry| {
+            if protected_run_id.is_some_and(|run_id| run_id == *entry.key()) {
+                None
+            } else {
+                Some((*entry.key(), entry.value().inserted_at))
+            }
+        })
+        .collect();
     records_by_age.sort_by_key(|(_, inserted_at)| *inserted_at);
 
     for (run_id, _) in records_by_age.into_iter().take(overflow) {
         runs.remove(&run_id);
     }
-    overflow
+    current_len.saturating_sub(runs.len())
 }
 
 fn describe_agent(spec: &AgentSpec) -> AgentDescriptor {
@@ -604,7 +633,7 @@ mod tests {
         runs.insert(stale_run, sample_record(stale_run, now - Duration::from_secs(120)));
         runs.insert(fresh_run, sample_record(fresh_run, now - Duration::from_secs(5)));
 
-        let removed = prune_expired_runs(&runs, now, ttl);
+        let removed = prune_expired_runs(&runs, now, ttl, None);
 
         assert_eq!(removed, 1);
         assert!(!runs.contains_key(&stale_run));
@@ -623,11 +652,55 @@ mod tests {
         runs.insert(middle, sample_record(middle, now - Duration::from_secs(20)));
         runs.insert(newest, sample_record(newest, now - Duration::from_secs(10)));
 
-        let removed = prune_to_max_entries(&runs, 2);
+        let removed = prune_to_max_entries(&runs, 2, None);
 
         assert_eq!(removed, 1);
         assert!(!runs.contains_key(&oldest));
         assert!(runs.contains_key(&middle));
+        assert!(runs.contains_key(&newest));
+    }
+
+    #[test]
+    fn prune_expired_runs_keeps_protected_run() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let protected = Uuid::new_v4();
+        let stale_unprotected = Uuid::new_v4();
+        let ttl = Duration::from_secs(30);
+
+        runs.insert(protected, sample_record(protected, now - Duration::from_secs(120)));
+        runs.insert(
+            stale_unprotected,
+            sample_record(stale_unprotected, now - Duration::from_secs(120)),
+        );
+
+        let removed = prune_expired_runs(&runs, now, ttl, Some(protected));
+
+        assert_eq!(removed, 1);
+        assert!(runs.contains_key(&protected));
+        assert!(!runs.contains_key(&stale_unprotected));
+    }
+
+    #[test]
+    fn prune_to_max_entries_keeps_protected_run() {
+        let runs = DashMap::new();
+        let now = Instant::now();
+        let protected_oldest = Uuid::new_v4();
+        let middle = Uuid::new_v4();
+        let newest = Uuid::new_v4();
+
+        runs.insert(
+            protected_oldest,
+            sample_record(protected_oldest, now - Duration::from_secs(30)),
+        );
+        runs.insert(middle, sample_record(middle, now - Duration::from_secs(20)));
+        runs.insert(newest, sample_record(newest, now - Duration::from_secs(10)));
+
+        let removed = prune_to_max_entries(&runs, 2, Some(protected_oldest));
+
+        assert_eq!(removed, 1);
+        assert!(runs.contains_key(&protected_oldest));
+        assert!(!runs.contains_key(&middle));
         assert!(runs.contains_key(&newest));
     }
 }

--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -54,6 +54,13 @@ struct RunRegistryPolicy {
     max_entries: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TenantInspectDisposition {
+    NotOwned,
+    ProtectRun,
+    Unprotected,
+}
+
 const DEFAULT_RUN_REGISTRY_TTL_SECS: u64 = 60 * 60 * 24;
 const DEFAULT_RUN_REGISTRY_MAX_ENTRIES: usize = 10_000;
 const RUN_REGISTRY_TTL_ENV: &str = "AGENT_RUN_REGISTRY_TTL_SECS";
@@ -177,19 +184,24 @@ impl AgentManager {
         run_id: RunId,
         tenant: &str,
     ) -> Result<Option<RunWithMetadata>> {
-        let is_owned_by_tenant = match self.runs.get(&run_id) {
-            Some(record) if record.tenant == tenant => true,
-            Some(_) => false,
+        let disposition = match self.runs.get(&run_id) {
+            Some(record) => tenant_inspect_disposition(record.value(), tenant),
             None => return Ok(None),
         };
 
-        if !is_owned_by_tenant {
-            // Do not protect foreign runs from pruning during unauthorized probes.
-            self.prune_run_registry();
-            return Ok(None);
+        match disposition {
+            TenantInspectDisposition::NotOwned => {
+                // Do not protect foreign runs from pruning during unauthorized probes.
+                self.prune_run_registry();
+                Ok(None)
+            }
+            TenantInspectDisposition::ProtectRun => self.inspect_inner(run_id, Some(run_id)).await,
+            TenantInspectDisposition::Unprotected => {
+                // Enforce TTL/cap for tenant-owned runs unless they are still awaiting approval.
+                self.prune_run_registry();
+                self.inspect_inner(run_id, None).await
+            }
         }
-
-        self.inspect_inner(run_id, Some(run_id)).await
     }
 
     pub async fn list_runs(
@@ -367,6 +379,16 @@ fn describe_agent(spec: &AgentSpec) -> AgentDescriptor {
         spec_version: spec.spec_version.clone(),
         tasks: spec.graph.tasks.clone(),
         checkpoint_count: spec.checkpoints.len(),
+    }
+}
+
+fn tenant_inspect_disposition(record: &RunRecord, tenant: &str) -> TenantInspectDisposition {
+    if record.tenant != tenant {
+        TenantInspectDisposition::NotOwned
+    } else if record.awaiting_approval {
+        TenantInspectDisposition::ProtectRun
+    } else {
+        TenantInspectDisposition::Unprotected
     }
 }
 
@@ -605,6 +627,36 @@ mod tests {
             inserted_at,
             awaiting_approval,
         }
+    }
+
+    #[test]
+    fn tenant_inspect_disposition_for_foreign_run_is_not_owned() {
+        let record = sample_record(Uuid::new_v4(), Instant::now(), false);
+
+        assert_eq!(
+            tenant_inspect_disposition(&record, "other-tenant"),
+            TenantInspectDisposition::NotOwned
+        );
+    }
+
+    #[test]
+    fn tenant_inspect_disposition_for_owned_awaiting_run_is_protected() {
+        let record = sample_record(Uuid::new_v4(), Instant::now(), true);
+
+        assert_eq!(
+            tenant_inspect_disposition(&record, "test-tenant"),
+            TenantInspectDisposition::ProtectRun
+        );
+    }
+
+    #[test]
+    fn tenant_inspect_disposition_for_owned_completed_run_is_unprotected() {
+        let record = sample_record(Uuid::new_v4(), Instant::now(), false);
+
+        assert_eq!(
+            tenant_inspect_disposition(&record, "test-tenant"),
+            TenantInspectDisposition::Unprotected
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a bounded in-memory run registry policy in `AgentManager` using TTL + max-entry retention
- make retention configurable via `AGENT_RUN_REGISTRY_TTL_SECS` and `AGENT_RUN_REGISTRY_MAX_ENTRIES` with startup validation
- prune stale/overflow entries on execute, inspect, list, and decision paths; add unit coverage for expiry and oldest-first eviction

## Related Issue

- Beads: `apex-dn3`

## Scope

### Changed files
- `crates/rag-server/src/agents.rs` - run registry policy, pruning logic, and retention unit tests

### Out of scope
- durable run/session persistence
- query-interaction memory store
- API contract changes to `/runs` endpoints

## Validation

| Check | Command | Result |
|---|---|---|
| Compilation | `cargo check -p rag-server` | pass |
| Unit tests | `cargo test -p rag-server --lib` | pass (62 passed) |
| Format | `cargo fmt` | pass |
| Format/lint/tests | `just test` | not run -- user decision |
| Integration (if relevant) | `just integration-tests` | not run -- not required for this in-memory retention change |

## Risk and Rollback

- Risk: medium -- retention pruning can expire historical run IDs sooner than before if TTL/max entries are configured too aggressively.
- Rollback: `git revert 281cca8` (or set larger values for `AGENT_RUN_REGISTRY_TTL_SECS` / `AGENT_RUN_REGISTRY_MAX_ENTRIES`), touching only `crates/rag-server/src/agents.rs`.

## Reviewer Focus

1. Verify pruning semantics on `inspect`/`decide` are acceptable for long-lived runs awaiting approval.
2. Verify env defaults and validation (`24h`, `10_000`) are operationally safe for phase-1 usage.

Generated with [Codex](https://Codex.com/Codex)