### PR TITLE
feat(routed-search): parameterize lexical-first FTS window

### DIFF
--- a/config/app.toml
+++ b/config/app.toml
@@ -50,6 +50,7 @@ request_id_header = "x-request-id"
 rrf_k = 60                                          # RRF fusion k parameter
 dense_top_k = 20                                    # Dense search result limit
 sparse_top_k = 20                                   # Sparse/BM25 search result limit
+lexical_fts_top_k = 10                              # Lexical-first FTS result limit for routed retrieval
 
 [context]
 max_tokens = 8000                                   # Token budget for assembled context

--- a/crates/agent-core/src/runtime/graph_flow/mod.rs
+++ b/crates/agent-core/src/runtime/graph_flow/mod.rs
@@ -53,6 +53,7 @@ pub struct GraphFlowRuntime {
     chat: Arc<dyn ChatPort>,
     approval: Arc<dyn ApprovalPort>,
     baseline: Arc<dyn BaselineAnswerPort>,
+    lexical_fts_top_k: u64,
     /// Optional spec driving graph construction. When `None`, falls back to
     /// the hardcoded 5-task spike graph.
     spec: Option<AgentSpec>,
@@ -61,6 +62,8 @@ pub struct GraphFlowRuntime {
     /// Run metadata indexed by run ID.
     meta: Arc<Mutex<std::collections::HashMap<RunId, RunMeta>>>,
 }
+
+const DEFAULT_LEXICAL_FTS_TOP_K: u64 = 10;
 
 struct UnavailableBaselineAnswerPort;
 
@@ -90,6 +93,7 @@ impl GraphFlowRuntime {
             chat,
             approval,
             baseline,
+            lexical_fts_top_k: DEFAULT_LEXICAL_FTS_TOP_K,
             spec: None,
             sessions: Arc::new(InMemorySessionStorage::new()),
             meta: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -118,10 +122,17 @@ impl GraphFlowRuntime {
             chat,
             approval,
             baseline,
+            lexical_fts_top_k: DEFAULT_LEXICAL_FTS_TOP_K,
             spec: Some(spec),
             sessions: Arc::new(InMemorySessionStorage::new()),
             meta: Arc::new(Mutex::new(std::collections::HashMap::new())),
         }
+    }
+
+    /// Set the lexical-first FTS retrieval window used by `retrieve_evidence`.
+    pub fn with_lexical_fts_top_k(mut self, lexical_fts_top_k: u64) -> Self {
+        self.lexical_fts_top_k = lexical_fts_top_k;
+        self
     }
 
     /// Create a runtime driven by a YAML agent spec and no baseline-answer port.
@@ -141,9 +152,10 @@ impl GraphFlowRuntime {
             BASELINE_ANSWER_TASK => {
                 Some(Arc::new(BaselineAnswerTask { baseline: self.baseline.clone() }))
             }
-            RETRIEVE_EVIDENCE_TASK => {
-                Some(Arc::new(RetrieveEvidenceTask { retrieval: self.retrieval.clone() }))
-            }
+            RETRIEVE_EVIDENCE_TASK => Some(Arc::new(RetrieveEvidenceTask {
+                retrieval: self.retrieval.clone(),
+                lexical_fts_top_k: self.lexical_fts_top_k,
+            })),
             COMPOSE_ANSWER_TASK => Some(Arc::new(ComposeAnswerTask { chat: self.chat.clone() })),
             CLASSIFY_TASK => Some(Arc::new(ClassifyTask)),
             HYBRID_SEARCH_TASK => {
@@ -556,6 +568,7 @@ mod tests {
     struct RoutedCallState {
         baseline_queries: Vec<String>,
         retrieval_calls: Vec<&'static str>,
+        fts_top_ks: Vec<u64>,
         compose_queries: Vec<String>,
         expand_requests: Vec<(String, String, i32, i32, i32)>,
     }
@@ -690,9 +703,11 @@ mod tests {
             _: &str,
             _: &str,
             _: &str,
-            _: u64,
+            top_k: u64,
         ) -> anyhow::Result<Vec<ScoredChunk>> {
-            self.state.lock().expect("retrieval state").retrieval_calls.push("fts");
+            let mut state = self.state.lock().expect("retrieval state");
+            state.retrieval_calls.push("fts");
+            state.fts_top_ks.push(top_k);
             Ok(self.fts_results.clone())
         }
 
@@ -953,10 +968,51 @@ graph:
         let state = state.lock().expect("call state");
         assert!(state.baseline_queries.is_empty(), "agentic route should bypass baseline answer");
         assert_eq!(state.retrieval_calls, vec!["fts", "hybrid"]);
+        assert_eq!(state.fts_top_ks, vec![DEFAULT_LEXICAL_FTS_TOP_K]);
         assert_eq!(
             state.compose_queries,
             vec!["How do I rotate API keys in the auth runbook?".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn routed_spec_uses_configured_lexical_fts_top_k() {
+        let state = Arc::new(Mutex::new(RoutedCallState::default()));
+        let runtime = GraphFlowRuntime::from_spec(
+            routed_spec(),
+            Arc::new(TrackingRetrieval {
+                state: state.clone(),
+                dense_results: Vec::new(),
+                fts_results: vec![test_chunk_with("chunk-fts", "doc-1", 0, "fts evidence")],
+                hybrid_results: vec![test_chunk_with(
+                    "chunk-hybrid",
+                    "doc-2",
+                    0,
+                    "hybrid evidence",
+                )],
+                expanded_results: Vec::new(),
+            }),
+            Arc::new(TrackingChat { state: state.clone() }),
+            Arc::new(StubApproval),
+            Arc::new(TrackingBaseline {
+                state: state.clone(),
+                grounded_answer: GroundedAnswer {
+                    answer: "baseline should not run".to_string(),
+                    search_results: Vec::new(),
+                    citations: Vec::new(),
+                    model: "baseline-model".to_string(),
+                },
+            }),
+        )
+        .with_lexical_fts_top_k(7);
+
+        let _result = runtime
+            .start(routed_config("How do I rotate API keys in the auth runbook?"))
+            .await
+            .expect("agentic route should complete");
+
+        let state = state.lock().expect("call state");
+        assert_eq!(state.fts_top_ks, vec![7]);
     }
 
     #[tokio::test]

--- a/crates/agent-core/src/runtime/graph_flow/tasks.rs
+++ b/crates/agent-core/src/runtime/graph_flow/tasks.rs
@@ -117,6 +117,7 @@ impl Task for BaselineAnswerTask {
 /// Executes deterministic retrieval selected by the route decision.
 pub struct RetrieveEvidenceTask {
     pub retrieval: Arc<dyn RetrievalPort>,
+    pub lexical_fts_top_k: u64,
 }
 
 #[async_trait::async_trait]
@@ -150,14 +151,15 @@ impl Task for RetrieveEvidenceTask {
                 })
             }
             RetrievalProfileId::LexicalFirst => {
-                let mut lexical =
-                    self.retrieval.search_fts(&collection, &query, &tenant, 10).await.map_err(
-                        |e| {
-                            graph_flow::GraphError::TaskExecutionFailed(format!(
-                                "retrieve evidence failed: {e}"
-                            ))
-                        },
-                    )?;
+                let mut lexical = self
+                    .retrieval
+                    .search_fts(&collection, &query, &tenant, self.lexical_fts_top_k)
+                    .await
+                    .map_err(|e| {
+                        graph_flow::GraphError::TaskExecutionFailed(format!(
+                            "retrieve evidence failed: {e}"
+                        ))
+                    })?;
                 let hybrid =
                     self.retrieval.search_hybrid(&collection, &query, &tenant).await.map_err(
                         |e| {

--- a/crates/rag-cli/tests/e2e.rs
+++ b/crates/rag-cli/tests/e2e.rs
@@ -58,6 +58,7 @@ async fn full_app() -> axum::Router {
             stores.clone(),
             retrieval.clone(),
             chat.clone(),
+            config.lexical_fts_top_k,
         )
         .await
         .expect("agents"),

--- a/crates/rag-core/src/config.rs
+++ b/crates/rag-core/src/config.rs
@@ -166,6 +166,7 @@ struct RetrievalSection {
     rrf_k: Option<u32>,
     dense_top_k: Option<u64>,
     sparse_top_k: Option<u64>,
+    lexical_fts_top_k: Option<u64>,
 }
 
 #[derive(Deserialize, Default)]
@@ -281,6 +282,7 @@ pub struct AppConfig {
     pub rrf_k: u32,
     pub dense_top_k: u64,
     pub sparse_top_k: u64,
+    pub lexical_fts_top_k: u64,
     // Context assembly
     pub context_max_tokens: usize,
     pub context_max_chunks: usize,
@@ -354,6 +356,7 @@ impl fmt::Debug for AppConfig {
             .field("rrf_k", &self.rrf_k)
             .field("dense_top_k", &self.dense_top_k)
             .field("sparse_top_k", &self.sparse_top_k)
+            .field("lexical_fts_top_k", &self.lexical_fts_top_k)
             .field("context_max_tokens", &self.context_max_tokens)
             .field("context_max_chunks", &self.context_max_chunks)
             .field("llm_provider", &self.llm_provider)
@@ -610,6 +613,11 @@ impl AppConfig {
         if sparse_top_k == 0 {
             anyhow::bail!("sparse_top_k must be greater than zero");
         }
+        let lexical_fts_top_k =
+            env_parsed("LEXICAL_FTS_TOP_K")?.or(r.lexical_fts_top_k).unwrap_or(10);
+        if lexical_fts_top_k == 0 {
+            anyhow::bail!("lexical_fts_top_k must be greater than zero");
+        }
         let context_max_tokens =
             env_parsed("CONTEXT_MAX_TOKENS")?.or(ctx.max_tokens).unwrap_or(8000);
         if context_max_tokens == 0 {
@@ -792,6 +800,7 @@ impl AppConfig {
             rrf_k,
             dense_top_k,
             sparse_top_k,
+            lexical_fts_top_k,
             context_max_tokens,
             context_max_chunks,
             llm_provider,
@@ -886,6 +895,7 @@ mod tests {
             std::env::remove_var("RRF_K");
             std::env::remove_var("DENSE_TOP_K");
             std::env::remove_var("SPARSE_TOP_K");
+            std::env::remove_var("LEXICAL_FTS_TOP_K");
             std::env::remove_var("CONTEXT_MAX_TOKENS");
             std::env::remove_var("CONTEXT_MAX_CHUNKS");
             std::env::remove_var("LLM_PROVIDER");
@@ -972,6 +982,7 @@ mod tests {
         assert_eq!(cfg.rrf_k, 60);
         assert_eq!(cfg.dense_top_k, 20);
         assert_eq!(cfg.sparse_top_k, 20);
+        assert_eq!(cfg.lexical_fts_top_k, 10);
         assert_eq!(cfg.context_max_tokens, 8000);
         assert_eq!(cfg.context_max_chunks, 50);
         assert_eq!(cfg.llm_provider, LlmProvider::OpenAiCompatible);
@@ -1041,7 +1052,19 @@ mod tests {
         assert!(err.contains("llm_max_tokens"), "error: {err}");
         unsafe { std::env::remove_var("LLM_MAX_TOKENS") };
 
-        // -- Part 4: pdfium_library_path from env --
+        // -- Part 4: lexical_fts_top_k override and validation --
+        unsafe { std::env::set_var("LEXICAL_FTS_TOP_K", "12") };
+        let cfg = AppConfig::from_current_env().expect("lexical_fts_top_k override");
+        assert_eq!(cfg.lexical_fts_top_k, 12);
+        unsafe { std::env::set_var("LEXICAL_FTS_TOP_K", "0") };
+        let err = AppConfig::from_current_env().expect_err("zero lexical_fts_top_k should fail");
+        assert!(
+            err.to_string().contains("lexical_fts_top_k"),
+            "error should mention lexical_fts_top_k: {err}"
+        );
+        unsafe { std::env::remove_var("LEXICAL_FTS_TOP_K") };
+
+        // -- Part 5: pdfium_library_path from env --
         unsafe { std::env::set_var("PDFIUM_LIBRARY_PATH", "/usr/local/lib/libpdfium.dylib") };
         let cfg = AppConfig::from_current_env().expect("from_env with PDFIUM_LIBRARY_PATH");
         assert_eq!(
@@ -1051,7 +1074,7 @@ mod tests {
         );
         unsafe { std::env::remove_var("PDFIUM_LIBRARY_PATH") };
 
-        // -- Part 5: TESSDATA_PREFIX env override --
+        // -- Part 6: TESSDATA_PREFIX env override --
         unsafe { std::env::set_var("TESSDATA_PREFIX", "/opt/tessdata") };
         let cfg = AppConfig::from_current_env().expect("from_env with TESSDATA_PREFIX");
         assert_eq!(
@@ -1061,7 +1084,7 @@ mod tests {
         );
         unsafe { std::env::remove_var("TESSDATA_PREFIX") };
 
-        // -- Part 6: ingest roots env override --
+        // -- Part 7: ingest roots env override --
         let root_a = tempfile::tempdir().expect("tempdir a");
         let root_b = tempfile::tempdir().expect("tempdir b");
         let roots_csv = format!("{},{}", root_a.path().display(), root_b.path().display());
@@ -1073,7 +1096,7 @@ mod tests {
         assert_eq!(cfg.ingest_allowed_roots[1], root_b.path().canonicalize().expect("canonical b"),);
         unsafe { std::env::remove_var("INGEST_ALLOWED_ROOTS") };
 
-        // -- Part 7: agent specs dir env override --
+        // -- Part 8: agent specs dir env override --
         let agent_specs_dir = tempfile::tempdir().expect("tempdir agent specs");
         unsafe { std::env::set_var("AGENT_SPECS_DIR", agent_specs_dir.path()) };
         let cfg = AppConfig::from_current_env().expect("from_env with AGENT_SPECS_DIR");
@@ -1083,7 +1106,7 @@ mod tests {
         );
         unsafe { std::env::remove_var("AGENT_SPECS_DIR") };
 
-        // -- Part 8: secret env vars load as redacted types --
+        // -- Part 9: secret env vars load as redacted types --
         unsafe {
             std::env::set_var("QDRANT_API_KEY", "qdrant-secret");
             std::env::set_var("BOOTSTRAP_PLATFORM_API_KEY", "bootstrap-secret");
@@ -1118,7 +1141,7 @@ mod tests {
             std::env::remove_var("LLM_API_KEY");
         }
 
-        // -- Part 9: zero ocr_timeout_secs rejected --
+        // -- Part 10: zero ocr_timeout_secs rejected --
         unsafe { std::env::set_var("OCR_TIMEOUT_SECS", "0") };
         let err = AppConfig::from_current_env()
             .expect_err("zero ocr_timeout_secs should be rejected")

--- a/crates/rag-core/src/embed.rs
+++ b/crates/rag-core/src/embed.rs
@@ -499,6 +499,7 @@ mod tests {
             rrf_k: 60,
             dense_top_k: 20,
             sparse_top_k: 20,
+            lexical_fts_top_k: 10,
             context_max_tokens: 8000,
             context_max_chunks: 50,
             llm_provider: LlmProvider::OpenAiCompatible,

--- a/crates/rag-core/src/llm.rs
+++ b/crates/rag-core/src/llm.rs
@@ -615,6 +615,7 @@ mod tests {
             rrf_k: 60,
             dense_top_k: 20,
             sparse_top_k: 20,
+            lexical_fts_top_k: 10,
             context_max_tokens: 8000,
             context_max_chunks: 50,
             llm_provider: LlmProvider::OpenAiCompatible,

--- a/crates/rag-server/src/agents.rs
+++ b/crates/rag-server/src/agents.rs
@@ -72,6 +72,7 @@ impl AgentManager {
         stores: Stores,
         retrieval: Arc<RetrievalService>,
         chat: Arc<ChatService>,
+        lexical_fts_top_k: u64,
     ) -> Result<Self> {
         let tool_registry = DefaultToolRegistry;
         let registry = agent_core::AgentRegistry::load_from_dir(
@@ -84,16 +85,19 @@ impl AgentManager {
 
         let mut runtimes: HashMap<String, Arc<dyn AgentRuntime>> = HashMap::new();
         for (agent_id, spec) in registry.list() {
-            let runtime: Arc<dyn AgentRuntime> = Arc::new(GraphFlowRuntime::from_spec(
-                spec.clone(),
-                Arc::new(ServerRetrievalPort {
-                    retrieval: retrieval.clone(),
-                    stores: stores.clone(),
-                }),
-                Arc::new(ServerChatPort { chat: chat.clone() }),
-                Arc::new(PauseForApproval),
-                Arc::new(ServerBaselineAnswerPort { chat: chat.clone() }),
-            ));
+            let runtime: Arc<dyn AgentRuntime> = Arc::new(
+                GraphFlowRuntime::from_spec(
+                    spec.clone(),
+                    Arc::new(ServerRetrievalPort {
+                        retrieval: retrieval.clone(),
+                        stores: stores.clone(),
+                    }),
+                    Arc::new(ServerChatPort { chat: chat.clone() }),
+                    Arc::new(PauseForApproval),
+                    Arc::new(ServerBaselineAnswerPort { chat: chat.clone() }),
+                )
+                .with_lexical_fts_top_k(lexical_fts_top_k),
+            );
             runtimes.insert(agent_id.clone(), runtime);
         }
 

--- a/crates/rag-server/src/main.rs
+++ b/crates/rag-server/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<()> {
             stores.clone(),
             retrieval.clone(),
             chat.clone(),
+            config.lexical_fts_top_k,
         )
         .await
         .context("loading agent manager")?,

--- a/crates/rag-server/tests/common/mod.rs
+++ b/crates/rag-server/tests/common/mod.rs
@@ -46,6 +46,7 @@ pub async fn full_app() -> (Router, Arc<AppState>) {
             stores.clone(),
             retrieval.clone(),
             chat.clone(),
+            config.lexical_fts_top_k,
         )
         .await
         .expect("agents"),


### PR DESCRIPTION
## Summary

- Replace the hardcoded lexical-first FTS limit (`10`) with a config-backed setting (`lexical_fts_top_k`) so routed retrieval tuning is explicit and consistent with existing retrieval knobs.
- Thread `lexical_fts_top_k` from `rag-core::AppConfig` through `rag-server::AgentManager` into `agent-core::GraphFlowRuntime` and `RetrieveEvidenceTask`.
- Add coverage for config default/override/validation and runtime usage of the configured FTS top-k in routed lexical-first execution.

## Related Issue

- Beads: `apex-v1g`

## Scope

### Changed files
- `config/app.toml` - add `[retrieval].lexical_fts_top_k` default and description.
- `crates/rag-core/src/config.rs` - parse/validate/env override (`LEXICAL_FTS_TOP_K`) and expose on `AppConfig`.
- `crates/agent-core/src/runtime/graph_flow/tasks.rs` - use configured `lexical_fts_top_k` for `RetrievalProfileId::LexicalFirst` FTS call.
- `crates/agent-core/src/runtime/graph_flow/mod.rs` - carry runtime setting, inject into `RetrieveEvidenceTask`, and test FTS top-k propagation.
- `crates/rag-server/src/agents.rs` and `crates/rag-server/src/main.rs` - pass server config into runtime construction.
- `crates/rag-server/tests/common/mod.rs` and `crates/rag-cli/tests/e2e.rs` - update `AgentManager::load_default` callsites.
- `crates/rag-core/src/llm.rs` and `crates/rag-core/src/embed.rs` - update `AppConfig` test fixtures with new field.

### Out of scope
- Any change to retrieval profile semantics beyond parameterizing the lexical-first FTS window.
- Any API contract changes for `/search/*` routes.
- Any integration-test matrix expansion beyond existing targeted checks.

## Validation

| Check | Command | Result |
|---|---|---|
| Format | `cargo fmt` | pass |
| Config unit coverage | `cargo test -p rag-core config::tests::from_env_defaults_and_override` | pass |
| Routed runtime behavior | `cargo test -p agent-core routed_spec_uses_retrieval_and_composition_for_agentic_queries` | pass |
| Routed FTS top-k propagation | `cargo test -p agent-core routed_spec_uses_configured_lexical_fts_top_k` | pass |
| Compilation | `cargo check -p rag-server` | pass |
| Test compile (server) | `cargo test -p rag-server --tests --no-run` | pass |
| Test compile (cli) | `cargo test -p rag-cli --test e2e --no-run` | pass |
| Full suite | `just test` | not run -- user decision |
| Integration suite | `just integration-tests` | not run -- not required for this config/runtime wiring change |

## Risk and Rollback

- Risk: **medium** -- cross-crate wiring (`rag-core` config -> `rag-server` runtime assembly -> `agent-core` retrieval task) could regress runtime construction if future callsites miss the new parameter.
- Rollback: revert commit `60bf5ff` (or revert touched files listed above) to restore hardcoded lexical-first FTS window behavior.

## Reviewer Focus

1. Confirm the config ownership and propagation path is correct and minimal (`AppConfig` -> `AgentManager::load_default` -> `GraphFlowRuntime` -> `RetrieveEvidenceTask`).
2. Confirm lexical-first behavior remains unchanged except for tunability, including default behavior staying at `10` when unset.

Generated with [Codex](https://Codex.com/Codex)
